### PR TITLE
Makefile now updates latex styles and enables new templates to be downloaded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *lsst-technote-bootstrap*
 *ipynb_checkpoints*
+templates

--- a/{{cookiecutter.folder_name}}/Makefile
+++ b/{{cookiecutter.folder_name}}/Makefile
@@ -7,8 +7,7 @@
 # To tar up a flat version of a specific format:
 # > make <format> tar
 #
-# Alex Drlica-Wagner <kadrlica@fnal.gov>
-#
+# Alex Drlica-Wagner: https://github.com/DarkEnergyScienceCollaboration/start_paper/issues/new?body=@kadrlica
 
 # Primary file names
 main=main
@@ -126,7 +125,7 @@ templates:
 	@echo "\nDownloading the latest versions of the template files, for reference: \n"
 	@mkdir -p templates
 	$(MAKE) $(TEMPLATES)
-	$(MAKE) this
+	$(MAKE) new
 	ls templates/*
 
 # Get a template copy of the latest Makefile, for reference:

--- a/{{cookiecutter.folder_name}}/Makefile
+++ b/{{cookiecutter.folder_name}}/Makefile
@@ -44,14 +44,14 @@ tarfiles=$(figures) $(tables) $(styles) $(bibs) $(source)
 all: export flag = ${draft}
 all: main
 
-copy: 
+copy:
 	cp ${main}.pdf ${outname}.pdf
 
 touch:
 	touch ${main}.tex
 
 # {% raw %}
-main : 
+main :
 	latexmk -g -pdf  \
 	-pdflatex='pdflatex %O -interaction=nonstopmode "${flag}\input{%S}"'  \
 	${main}
@@ -67,7 +67,7 @@ tar : main
 # http://stackoverflow.com/q/8028314/
 TARGETS=apj apjl prd prl mnras note
 $(TARGETS): export flag = \def\flag{$(@)}
-$(TARGETS): 
+$(TARGETS):
 	$(MAKE) -e main
 	$(MAKE) -e tar
 
@@ -77,3 +77,26 @@ tidy:
 
 clean: tidy
 	rm -f ${main}.pdf ${main}.tar.gz
+
+baseurl=https://raw.githubusercontent.com/DarkEnergyScienceCollaboration/start_paper/master/%7B%7Bcookiecutter.folder_name%7D%7D
+
+UPDATES=\
+texmf/bib/apj.bst \
+texmf/bib/mnras.bst \
+texmf/styles/aas_macros.sty \
+texmf/styles/aastex.cls \
+texmf/styles/aastex61.cls \
+texmf/styles/aps_macros.sty \
+texmf/styles/docswitch.sty \
+texmf/styles/emulateapj.cls \
+texmf/styles/mnras.cls \
+.logos/desc-logo-small.png \
+.logos/desc-logo.png \
+.logos/header.png
+
+.PHONY: $(UPDATES)
+$(UPDATES):
+	curl -s -S -o $(@) ${baseurl}/$(@)
+
+update:
+	$(MAKE) $(UPDATES)

--- a/{{cookiecutter.folder_name}}/Makefile
+++ b/{{cookiecutter.folder_name}}/Makefile
@@ -78,6 +78,8 @@ tidy:
 clean: tidy
 	rm -f ${main}.pdf ${main}.tar.gz
 
+# Update the tex styles etc:
+
 baseurl=https://raw.githubusercontent.com/DarkEnergyScienceCollaboration/start_paper/master/%7B%7Bcookiecutter.folder_name%7D%7D
 
 UPDATES=\
@@ -97,6 +99,32 @@ texmf/styles/mnras.cls \
 .PHONY: $(UPDATES)
 $(UPDATES):
 	curl -s -S -o $(@) ${baseurl}/$(@)
+	@echo " "
 
 update:
+	@echo "\nOver-writing LaTeX style files with the latest versions: \n"
 	$(MAKE) $(UPDATES)
+
+# Get fresh copies of the templates etc, for reference:
+
+TEMPLATES=\
+Makefile \
+acknowledgments.tex \
+authors.tex \
+macros.tex \
+main.bib \
+main.ipynb \
+main.md \
+main.rst \
+main.tex
+
+.PHONY: $(TEMPLATES) templates
+$(TEMPLATES):
+	curl -s -S -o templates/$(@) ${baseurl}/$(@)
+	@echo " "
+
+templates:
+	@echo "\nDownloading the latest versions of the template files, for reference: \n"
+	@mkdir -p templates
+	$(MAKE) $(TEMPLATES)
+	ls templates/*

--- a/{{cookiecutter.folder_name}}/Makefile
+++ b/{{cookiecutter.folder_name}}/Makefile
@@ -108,7 +108,6 @@ update:
 # Get fresh copies of the templates etc, for reference:
 
 TEMPLATES=\
-Makefile \
 acknowledgments.tex \
 authors.tex \
 macros.tex \
@@ -127,4 +126,20 @@ templates:
 	@echo "\nDownloading the latest versions of the template files, for reference: \n"
 	@mkdir -p templates
 	$(MAKE) $(TEMPLATES)
+	$(MAKE) this
 	ls templates/*
+
+# Get a template copy of the latest Makefile, for reference:
+.PHONY: new
+new:
+	@echo "\nDownloading the latest version of the Makefile, for reference: \n"
+	@mkdir -p templates
+	curl -s -S -o templates/Makefile ${baseurl}/Makefile
+	@echo " "
+
+# Over-write this Makefile with the latest version:
+.PHONY: upgrade
+upgrade:
+	@echo "\nDownloading the latest version of the Makefile: \n"
+	curl -s -S -o Makefile ${baseurl}/Makefile
+	@echo "\nNow get the latest styles and templates with\n\n    make update\n    make templates\n"

--- a/{{cookiecutter.folder_name}}/README.md
+++ b/{{cookiecutter.folder_name}}/README.md
@@ -33,8 +33,11 @@ The template files (`main.*` etc) are also likely to be updated; to get fresh co
 ```
 make templates
 ```
-However, since you will have edited at least one of the templates in your folder, `make templates` creates a special `templates` folder for you to refer to. Finally, to get new style or template files that are added to the `start_paper` project, you'll need to first get the latest `Makefile`, and then `make update` and/or `make templates`. The command to obtain the latest `Makefile` is
+However, since you will have edited at least one of the templates in your folder, `make templates` creates a special `templates` folder for you to refer to. Finally, to get *new* style or template files that are added to the `start_paper` project, you'll need to first get the latest `Makefile`, and then `make update` and/or `make templates`. The command to obtain the latest `Makefile` is
 ```
-make make
+make new
 ```
-> NB. `make make` will over-write your existing `Makefile`! If you just want to *see* the latest `Makefile`, but not adopt it blindly (perhaps because you have edited the `Makefile` locally), just do `make templates` and read it in the `templates` folder.
+This will add the latest `Makefile` to your `templates` folder. If you want to over-write your existing `Makefile`, you can do
+```
+make upgrade
+``` 

--- a/{{cookiecutter.folder_name}}/README.md
+++ b/{{cookiecutter.folder_name}}/README.md
@@ -23,3 +23,18 @@ You can compile latex papers locally with
 ```
 make  [note|apj|apjl|prd|prl|mnras]
 ```
+
+From time to time, the latex style files will be updated: to re-download the latest versions, do
+```
+make update
+```
+This will over-write your folder's copies - but that's OK, as they are not meant to be edited by you!
+The template files (`main.*` etc) are also likely to be updated; to get fresh copies of these files, do
+```
+make templates
+```
+However, since you will have edited at least one of the templates in your folder, `make templates` creates a special `templates` folder for you to refer to. Finally, to get new style or template files that are added to the `start_paper` project, you'll need to first get the latest `Makefile`, and then `make update` and/or `make templates`. The command to obtain the latest `Makefile` is
+```
+make make
+```
+> NB. `make make` will over-write your existing `Makefile`! If you just want to *see* the latest `Makefile`, but not adopt it blindly (perhaps because you have edited the `Makefile` locally), just do `make templates` and read it in the `templates` folder.

--- a/{{cookiecutter.folder_name}}/main.tex
+++ b/{{cookiecutter.folder_name}}/main.tex
@@ -1,5 +1,9 @@
 % {% raw %}
 \RequirePackage{docswitch}
+% \flag is set by the user, through the makefile:
+%    make note
+%    make apj
+% etc.
 \setjournal{\flag}
 
 \documentclass[\docopts]{\docclass}
@@ -18,7 +22,7 @@
 %% Start the Document %%
 %%%%%%%%%%%%%%%%%%%%%%%%
 
-\begin{document} 
+\begin{document}
 
 \title{LSST DESC Document Template}
 
@@ -36,11 +40,11 @@ This is going to be a fantastic paper!
 \section{Introduction}
 \label{sec:intro}
 
-This is a paper and note template for the LSST DESC \citep{Overview,ScienceBook,WhitePaper}.  
+This is a paper and note template for the LSST DESC \citep{Overview,ScienceBook,WhitePaper}.
 Eventually it will be possible to switch between various \LaTeX\xspace styles for internal notes and peer reviewed journals templates.
-The base switch is between \code{aastex.cls} and \code{revtex.cls}; however, facilities are also provided for \code{emulateapj.cls} and \code{mnras.cls}.\footnote{The \code{mnras.cls} class file is a bit odd...}  
-Documents can be compiled using the provided \code{Makefile} with several options: \code{make apj}, \code{make apjl}, \code{make prd}, and \code{make mnras}. 
-There are some oddities when changing between templates, so please be patient while we try to work these out. 
+The base switch is between \code{aastex.cls} and \code{revtex.cls}; however, facilities are also provided for \code{emulateapj.cls} and \code{mnras.cls}.\footnote{The \code{mnras.cls} class file is a bit odd...}
+Documents can be compiled using the provided \code{Makefile} with several options: \code{make apj}, \code{make apjl}, \code{make prd}, and \code{make mnras}.
+There are some oddities when changing between templates, so please be patient while we try to work these out.
 
 \section{Commands}
 \label{sec:commands}
@@ -49,8 +53,8 @@ There are a number of useful \LaTeX\xspace commands predefined in \code{macros.t
 Notice that the section labels are prefixed with \code{sec:} to allow the use of the \verb=\secref= command to reference a section (\ie, \secref{intro}).
 Figures can be referenced with the \verb=\figref= command, which assumes that the figure label is prefixed with \code{fig:}.
 In \figref{example} we show an example figure.
-You'll notice that the actual figure file is found in the \code{figures} directory. 
-However, because we have specified this directory in our \verb=\graphicspath= we do not need to explicitly specify the path to the image. 
+You'll notice that the actual figure file is found in the \code{figures} directory.
+However, because we have specified this directory in our \verb=\graphicspath= we do not need to explicitly specify the path to the image.
 
 The \code{macros.tex} package also contains some conventional scientific units like \angstrom, \GeV, \Msun, etc. and some editorial tools for highlighting \FIXME{issues}, \CHECK{text to be checked}, \COMMENT{comments}, and \NEW{new additions}.
 
@@ -58,8 +62,8 @@ The \code{macros.tex} package also contains some conventional scientific units l
 \section{Methods}
 \label{sec:methods}
 
-Similar to the figure before, here we have included a table of data from \code{tables/table.tex}.  
-Notice that again we are able to reference \tabref{example} with the \verb=\tabref= command using the \code{tab:} prefix. 
+Similar to the figure before, here we have included a table of data from \code{tables/table.tex}.
+Notice that again we are able to reference \tabref{example} with the \verb=\tabref= command using the \code{tab:} prefix.
 Also notice that we haven't needed to specify the full path to the table because in the \code{Makefile} we include \code{./tables} directory in the \code{\$TEXINPUTS} environment variable.
 
 \input{table}
@@ -67,7 +71,7 @@ Also notice that we haven't needed to specify the full path to the table because
 \section{Results}
 \label{sec:results}
 
-If you are planning on committing your paper to github, it's a good idea to write your tex as one sentence per line. 
+If you are planning on committing your paper to github, it's a good idea to write your tex as one sentence per line.
 This allows for an easier \code{diff} of changes.
 
 \section{Discussion}

--- a/{{cookiecutter.folder_name}}/texmf/styles/docswitch.sty
+++ b/{{cookiecutter.folder_name}}/texmf/styles/docswitch.sty
@@ -52,7 +52,8 @@
 
   % Set the values for PRD
   \ifdefstring{#1}{prd}{
-    \renewcommand\docopts{aps,prd,preprint,superscriptaddress,floatfix,nofootinbib}
+    \renewcommand\docopts{aps,prd,preprint,superscriptaddress,floatfix,nofootinbib,
+    showkeys}
   }{}
 
   % Set the values for emulateapj


### PR DESCRIPTION
I tried to be safe here: `make update` downloads the style files, over-writing the existing ones. `make templates` downloads the templates, into a `templates` folder, for reference. The logic was to try and avoid people over-writing their files if at all possible! To get *new* files (like the upcoming `lsst-desc-note.cls`), users would first download a new `Makefile` (containing a longer list of files to update) and then update the style files. That two-step sequence looks like this:
```
make upgrade
make update
```
What do you think, @kadrlica ?
