### PR TITLE
Added some tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
 
 # Now make the PDF, and move it to the top level, ready for deployment.
 script:
-  - nosetest -s tests/
+  - nosetests -s tests/
   - make -C doc/desc-0000-start_paper-intro
   - cp doc/desc-0000-start_paper-intro/desc-0000-start_paper-intro.pdf .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
 
 # Now make the PDF, and move it to the top level, ready for deployment.
 script:
-  - nosetests -s tests/
+  - nosetests tests/
   - make -C doc/desc-0000-start_paper-intro
   - cp doc/desc-0000-start_paper-intro/desc-0000-start_paper-intro.pdf .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,15 @@ addons:
             - texlive-publishers
 install:
 
+before_script:
+  - pip install cookiecutter
+  - pip install nose
+
 # Now make the PDF, and move it to the top level, ready for deployment.
 script:
-    - make -C doc/desc-0000-start_paper-intro
-    - cp doc/desc-0000-start_paper-intro/desc-0000-start_paper-intro.pdf .
+  - nosetest -s tests/
+  - make -C doc/desc-0000-start_paper-intro
+  - cp doc/desc-0000-start_paper-intro/desc-0000-start_paper-intro.pdf .
 
 # Finally, if it's the master branch being updated, force-push the
 # resulting PDF to an otherwise empty "pdf" branch:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ addons:
 install:
 
 before_script:
-  - pip install cookiecutter
-  - pip install nose
+  - pip install --user cookiecutter
+  - pip install --user nose
 
 # Now make the PDF, and move it to the top level, ready for deployment.
 script:

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -12,12 +12,12 @@ srcdir="./{{cookiecutter.folder_name}}"
 
 commands = [
     ['make'],
-#    ['make','tex'],
-#    ['make','apj'],
-#    ['make','apjl'],
-#    ['make','prl'],
-#    ['make','prd'],
-#    ['make','mnras'],
+    ['make','tex'],
+    ['make','apj'],
+    ['make','apjl'],
+    ['make','prl'],
+    ['make','prd'],
+    ['make','mnras'],
 ]
 
 class TestMake(unittest.TestCase):

--- a/tests/test_make.py
+++ b/tests/test_make.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+"""
+Test latex compilation script
+"""
+__author__ = "Alex Drlica-Wagner"
+
+import os
+import shutil
+import logging
+from subprocess import Popen, PIPE
+import unittest
+
+commands = [
+    ['make'],
+#    ['make','tex'],
+#    ['make','apj'],
+#    ['make','apjl'],
+#    ['make','prl'],
+#    ['make','prd'],
+#    ['make','mnras'],
+]
+
+class TestMake(unittest.TestCase):
+
+    def setUp(self):
+        os.chdir("{{cookiecutter.folder_name}}")
+
+    def tearDown(self):
+        self.runcmd('make clean')
+        os.chdir("..")
+
+    def runcmd(self, cmd):
+        print(cmd)
+        p = Popen(cmd.split(),stdout=PIPE,stderr=PIPE)
+        stdout,stderr = p.communicate()
+        print(stdout)
+        if p.returncode > 0:
+            raise Exception(stderr)
+
+# Can't be named 'test' or nose will find it
+def create_func(args):
+    def func(self):
+        if isinstance(args,basestring): self.runcmd(args)
+        else: self.runcmd(' '.join(args))
+    return func
+
+for args in commands:
+    test_method = create_func(args)
+    test_method.__name__ = 'test_%s' % ('_'.join(args))
+    setattr (TestMake, test_method.__name__, test_method)
+    # Need to delete the method or nose will find it
+    del test_method
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I've added at `tests` directory and a file (`test_make.py`) that can be run with python's testing modules (i.e., `nose`). This closes #20 (for the time being), but eventually we will need to think about what travis should run during development (i.e., test scripts) and what it should run during deployment (i.e., making the pdf).