### PR TITLE
Prompt for default format, store it in .metadata.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Use `cookiecutter` to make a folder containing everything you need to start writ
 
 ## Why should I use this tool?
 
-1. It'll save you some set-up time, which you can spend time writing about science instead.
+1. It'll save you some paper set-up time.
 2. It'll help you comply with the LSST DESC Publication Policy, which places some requirements on papers to state the contributions of its authors.
-3. It'll save you some writing time, by automagically writing the author list and acknowledgments, and getting the latex styling right,  for you.
+3. It'll save you some writing time, by automagically constructing the author list and acknowledgments, and getting the latex styling right,  for you.
 
 ## How do I use it?
 
@@ -29,9 +29,14 @@ short_title [paper_title]: intro
 serial_number [0000]: 0000
 repo_name [ProjectName]: start_paper
 folder_name [desc-0000-start_paper-intro]:
+default_format [tex]: apj
 ```
 
-The folder that is then produced (silently!) will have the `folder_name` that you entered, and it will contain several pre-configured template files. For LSST DESC Notes, you have a range of format choices available to you: Markdown, rST, ipynb and latex. For latex journal papers, we also provide the AJ style files for convenience, as well as some useful macros. Just choose a format, and start writing in that file!
+The folder that is then produced (silently!) will have the `folder_name` that you entered, and it will contain several pre-configured template files. For LSST DESC Notes, you have a range of format choices available to you: `md`, `rst`, `ipynb` and `tex`.
+
+For latex journal papers, we provide a number of style files for convenience, as well as some useful macros. Just choose a format (`apj`, `apjl`, `mnras`, `prd`, `prl`, `tex`, `md`, `rst`, `ipynb`) and start writing in that file! Templates for all formats are provided, so you can switch to a different one at any time. For example, your `default_format` might be `tex`, but `make apjl` will produce a PDF of your note using the ApJL style file.
+
+> For now, `make ipynb` still causes the `main.tex` file to be compiled. In future, we'll enable compilation of PDF or HTML from IPython notebooks.
 
 Don't forget to `git add` and `git commit` the files you edit, in the usual way. You might want to delete the templates you don't use - although if you think you might one day want to upgrade from markdown to latex, or from a Note to a journal article, you could keep those files around.
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -5,5 +5,6 @@
     "short_title": "paper_title",
     "serial_number": "0000",
     "repo_name": "ProjectName",
-    "folder_name": "desc-{{ cookiecutter.serial_number }}-{{ cookiecutter.repo_name.lower() }}-{{ cookiecutter.short_title.lower() }}"
+    "folder_name": "desc-{{ cookiecutter.serial_number }}-{{ cookiecutter.repo_name.lower() }}-{{ cookiecutter.short_title.lower() }}",
+    "default_format": "tex"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,11 +1,9 @@
 {
-    "initial_author": "First Last",
-    "initial_affiliation": "Institution, address",
+    "authors": "First Author, Second Author, Another Author",
     "title": "The Title of This Paper",
     "description": "A very brief description of your paper, for the folder's README. (Once you've typed this, you'll be asked for three more items: a short_title, a serial_number, and the project repo name. These will then be used to set the paper's folder name. The serial number can be changed later, so choosing 0000 is fine.)",
     "short_title": "paper_title",
     "serial_number": "0000",
     "repo_name": "ProjectName",
-    "folder_name": "desc-{{ cookiecutter.serial_number }}-{{ cookiecutter.repo_name.lower() }}-{{ cookiecutter.short_title.lower() }}",
-    "default_format": "tex"
+    "folder_name": "desc-{{ cookiecutter.serial_number }}-{{ cookiecutter.repo_name.lower() }}-{{ cookiecutter.short_title.lower() }}"
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,9 +1,11 @@
 {
-    "authors": "First Author, Second Author, Another Author",
+    "initial_author": "First Last",
+    "initial_affiliation": "Institution, address",
     "title": "The Title of This Paper",
     "description": "A very brief description of your paper, for the folder's README. (Once you've typed this, you'll be asked for three more items: a short_title, a serial_number, and the project repo name. These will then be used to set the paper's folder name. The serial number can be changed later, so choosing 0000 is fine.)",
     "short_title": "paper_title",
     "serial_number": "0000",
     "repo_name": "ProjectName",
-    "folder_name": "desc-{{ cookiecutter.serial_number }}-{{ cookiecutter.repo_name.lower() }}-{{ cookiecutter.short_title.lower() }}"
+    "folder_name": "desc-{{ cookiecutter.serial_number }}-{{ cookiecutter.repo_name.lower() }}-{{ cookiecutter.short_title.lower() }}",
+    "default_format": "tex"
 }

--- a/{{cookiecutter.folder_name}}/.metadata.json
+++ b/{{cookiecutter.folder_name}}/.metadata.json
@@ -1,0 +1,10 @@
+{
+    "authors": "{{ cookiecutter.authors }}",
+    "title": "{{ cookiecutter.title }}",
+    "description": "{{ cookiecutter.description }}",
+    "short_title": "{{ cookiecutter.short_title }}",
+    "serial_number": "{{ cookiecutter.serial_number }}",
+    "repo_name": "{{ cookiecutter.repo_name }}",
+    "folder_name": "{{ cookiecutter.folder_name }}",
+    "default_format": "{{ cookiecutter.default_format }}"
+}

--- a/{{cookiecutter.folder_name}}/Makefile
+++ b/{{cookiecutter.folder_name}}/Makefile
@@ -12,6 +12,7 @@
 # Primary file names - avoid cookiecutter variables, to enable `make
 # upgrade` to cleanly over-write this Makefile...
 main=main
+default=$(shell cat .metadata.json | grep 'default_format' | cut -d'"' -f4)
 outname=$(notdir $(shell pwd))
 
 # LATEX environment variables
@@ -36,12 +37,17 @@ tabdir=./tables
 tables=$(tabdir)/*.tex
 styles=./texmf/styles/*.{sty,cls}
 bibs=./texmf/bib/*.bst
-source=$(main).{tex,bbl,bib} lsstdesc.bib macros.tex authors.tex acknowledgments.tex
+source=$(main).{tex,bbl,bib} lsstdesc.bib authors.tex acknowledgments.tex
 
 tarfiles=$(figures) $(tables) $(styles) $(bibs) $(source)
 
-# Interpret `make` with no target as `make tex`, a latex Note
-all: export flag = \def\flag{tex}
+# Interpret `make` with no target as `make tex`, a latex Note.
+# At present, if the default_format is anything other than
+# [apj|apjl|mnras|prd|prl|emulateapj], a latex Note is made.
+# In future, we could think of using `make` to eg run the ipynb 
+# notebook and make PDF from the output, but this has not been
+# implemented yet.
+all: export flag=\def\flag{$(default)}
 all: main copy
 
 copy:
@@ -100,6 +106,7 @@ texmf/styles/docswitch.sty \
 texmf/styles/emulateapj.cls \
 texmf/styles/mnras.cls \
 texmf/styles/lsstdescnote.cls \
+texmf/styles/lsstdesc_macros.sty \
 .logos/desc-logo-small.png \
 .logos/desc-logo.png \
 .logos/header.png \
@@ -122,7 +129,6 @@ update:
 TEMPLATES=\
 acknowledgments.tex \
 authors.tex \
-macros.tex \
 main.ipynb \
 main.md \
 main.rst \

--- a/{{cookiecutter.folder_name}}/README.md
+++ b/{{cookiecutter.folder_name}}/README.md
@@ -48,7 +48,7 @@ make upgrade
 
 If this project is in a public GitHub repo, you can use the `.travis.yml` file in this folder to cause [travis-ci](http://travis-ci.org) to compile your paper into a PDF in the base repo at GitHub every time you push a commit to the master branch. The paper should appear as:
 
-**https://github.com/DarkEnergyScienceCollaboration/{{ cookiecutter.repo_name }}/tree/pdf/{{ cookiecutter.folder_name }}.pdf**
+**https://github.com/DarkEnergyScienceCollaboration/{{ cookiecutter.repo_name }}/tree/pdf{{ cookiecutter.folder_name }}.pdf**
 
 To enable this service, you need to follow these steps:
 

--- a/{{cookiecutter.folder_name}}/README.md
+++ b/{{cookiecutter.folder_name}}/README.md
@@ -22,7 +22,7 @@ You can compile latex papers locally with
 ```
 make  [apj|apjl|prd|prl|mnras]
 ```
-`make` with no arguments compiles the latex using the `texmf/styles/lsstdescnote.cls` class, with commands defined in `texmf/styles/lsstdesc_macros.sty`. (`make tex` does the same thing.) Don't edit these style files, as you may want to replace them with newer versions as they become available. Instead, use the `macros.tex` file to add your own `newcommand`'s and `def`'s.
+`make` with no arguments compiles the latex using the `texmf/styles/lsstdescnote.cls` class, with commands defined in `texmf/styles/lsstdesc_macros.sty`. Don't edit these style files, as you may want to replace them with newer versions as they become available. Instead, use the `macros.tex` file to add your own `newcommand`'s and `def`'s.
 
 ## Updating the Styles and Templates
 

--- a/{{cookiecutter.folder_name}}/README.md
+++ b/{{cookiecutter.folder_name}}/README.md
@@ -22,7 +22,7 @@ You can compile latex papers locally with
 ```
 make  [apj|apjl|prd|prl|mnras]
 ```
-`make` with no arguments compiles the latex using the `texmf/styles/lsstdescnote.cls` class, with commands defined in `texmf/styles/lsstdesc_macros.sty`. Don't edit these style files, as you may want to replace them with newer versions as they become available. Instead, use the `macros.tex` file to add your own `newcommand`'s and `def`'s.
+`make` with no arguments compiles the latex using the `texmf/styles/lsstdescnote.cls` class, with commands defined in `texmf/styles/lsstdesc_macros.sty`. (`make tex` does the same thing.) Don't edit these style files, as you may want to replace them with newer versions as they become available. Instead, use the `macros.tex` file to add your own `newcommand`'s and `def`'s.
 
 ## Updating the Styles and Templates
 

--- a/{{cookiecutter.folder_name}}/README.md
+++ b/{{cookiecutter.folder_name}}/README.md
@@ -22,7 +22,9 @@ You can compile latex papers locally with
 ```
 make  [apj|apjl|prd|prl|mnras]
 ```
-`make` with no arguments compiles the latex using the `texmf/styles/lsstdescnote.cls` class, with commands defined in `texmf/styles/lsstdesc_macros.sty`. Don't edit these style files, as you may want to replace them with newer versions as they become available. Instead, use the `macros.tex` file to add your own `newcommand`'s and `def`'s.
+`make` with no arguments compiles the latex using the `default_format` stored in `.metadata.json`. Choosing `tex` causes the paper to be made using the `texmf/styles/lsstdescnote.cls` class, with commands defined in `texmf/styles/lsstdesc_macros.sty`. Don't edit these style files, as you may want to replace them with newer versions as they become available. Instead, use the `macros.tex` file to add your own `newcommand`'s and `def`'s.
+
+At present, the Makefile is only used to compile latex. In future, we hope to enable compilation of jupyter notebooks, `Markdown` and `reStructuredText` format notes into PDF as well.
 
 ## Updating the Styles and Templates
 

--- a/{{cookiecutter.folder_name}}/README.md
+++ b/{{cookiecutter.folder_name}}/README.md
@@ -48,7 +48,7 @@ make upgrade
 
 If this project is in a public GitHub repo, you can use the `.travis.yml` file in this folder to cause [travis-ci](http://travis-ci.org) to compile your paper into a PDF in the base repo at GitHub every time you push a commit to the master branch. The paper should appear as:
 
-**https://github.com/DarkEnergyScienceCollaboration/{{ cookiecutter.repo_name }}/tree/pdf{{ cookiecutter.folder_name }}.pdf**
+**https://github.com/DarkEnergyScienceCollaboration/{{ cookiecutter.repo_name }}/tree/pdf/{{ cookiecutter.folder_name }}.pdf**
 
 To enable this service, you need to follow these steps:
 

--- a/{{cookiecutter.folder_name}}/contributions.csv
+++ b/{{cookiecutter.folder_name}}/contributions.csv
@@ -1,0 +1,2 @@
+Author Name,  Author Affiliation, JoinedAsBuilder, Contribution
+"{{ cookiecutter.initial_author }}", "{{ cookiecutter.initial_affiliation }}", "False", "started the paper."

--- a/{{cookiecutter.folder_name}}/contributions.csv
+++ b/{{cookiecutter.folder_name}}/contributions.csv
@@ -1,2 +1,0 @@
-Author Name,  Author Affiliation, JoinedAsBuilder, Contribution
-"{{ cookiecutter.initial_author }}", "{{ cookiecutter.initial_affiliation }}", "False", "started the paper."


### PR DESCRIPTION
The Makefile still only makes tex-format notes, but we at least now have a default format specified, so that `make` build an ApJ paper if that's all you ever want to do. I say we punt the `make`-ing of ipynb, md and rst files for another issue. What do you think, @kadrlica ? This is ready for review, IMO.